### PR TITLE
Fix boost 1.88+

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,0 +1,23 @@
+name: PR Build
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build_linux:
+    name: Build ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64-unknown-linux-gnu]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - run: sudo apt update && sudo apt install -y build-essential libboost-all-dev
+      - run: cargo build --release --all-targets --target ${{ matrix.target }}
+      - run: cargo test --release --all-targets --target ${{ matrix.target }}
+      - run: cargo run --release --target ${{ matrix.target }} -- --version

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -24,8 +24,8 @@ eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
 set(PROJECT_VERSION "0.77.0")
-# OSX target needed in order to support std::visit
-set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
+  # OSX target needed in order to support std::visit
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "15.4")
 project(solidity VERSION ${PROJECT_VERSION} LANGUAGES C CXX)
 
 include(TestBigEndian)
@@ -34,9 +34,9 @@ if (IS_BIG_ENDIAN)
 	message(FATAL_ERROR "${PROJECT_NAME} currently does not support big endian systems.")
 endif()
 
-option(SOLC_LINK_STATIC "Link solc executable statically on supported platforms" OFF)
+option(SOLC_LINK_STATIC "Link solc executable statically on supported platforms" ON)
 option(WITH_TESTS "Run solc tests" OFF)
-option(SOLC_STATIC_STDLIBS "Link solc against static versions of libgcc and libstdc++ on supported platforms" OFF)
+option(SOLC_STATIC_STDLIBS "Link solc against static versions of libgcc and libstdc++ on supported platforms" ON)
 option(STRICT_Z3_VERSION "Use the latest version of Z3" ON)
 option(PEDANTIC "Enable extra warnings and pedantic build flags. Treat all warnings as errors." ON)
 option(PROFILE_OPTIMIZER_STEPS "Output performance metrics for the optimiser steps." OFF)
@@ -90,4 +90,5 @@ endif()
 
 if (NOT EMSCRIPTEN)
 	add_subdirectory(solc)
+	target_link_libraries(solc PRIVATE Boost::process)
 endif()

--- a/compiler/cmake/EthDependencies.cmake
+++ b/compiler/cmake/EthDependencies.cmake
@@ -29,7 +29,7 @@ if (WIN32)
 	option(Boost_USE_STATIC_RUNTIME "Link Boost against static C++ runtime libraries" ON)
 endif()
 
-set(BOOST_COMPONENTS "filesystem;unit_test_framework;program_options;system")
+set(BOOST_COMPONENTS "filesystem;unit_test_framework;program_options;system;process")
 
 if (WIN32)
 	# Boost 1.77 fixes a bug that causes crashes on Windows for some relative paths in --allow-paths.


### PR DESCRIPTION
- Add Boost process component to EthDependencies.cmake
- Introduce new PR build workflow in .github/workflows/pr-build.yaml
- Update SMTSolverCommand.cpp to use Boost process v1 APIs
- Adjust CMakeLists.txt to link Boost::process and enable static linking