### PR TITLE
Add gosh.vergrth16WithVK builtin for caller-supplied Groth16 VK

### DIFF
--- a/compiler/libsolidity/analysis/ViewPureChecker.cpp
+++ b/compiler/libsolidity/analysis/ViewPureChecker.cpp
@@ -400,6 +400,7 @@ void ViewPureChecker::endVisit(MemberAccess const& _memberAccess)
 			{MagicType::Kind::Gosh, "zip"},
 			{MagicType::Kind::Gosh, "zipDiff"},
 			{MagicType::Kind::Gosh, "vergrth16"},
+			{MagicType::Kind::Gosh, "vergrth16WithVK"},
 			{MagicType::Kind::Gosh, "poseidon"},
 			{MagicType::Kind::Gosh, "zkhalo2verify"},
 			{MagicType::Kind::Gosh, "check_layer_hash"},

--- a/compiler/libsolidity/ast/Types.cpp
+++ b/compiler/libsolidity/ast/Types.cpp
@@ -3463,6 +3463,7 @@ std::string FunctionType::richIdentifier() const
 	case Kind::GoshSHA256: id += "goshsha256"; break;
 	case Kind::GoshKECCAK256: id += "goshkeccak256"; break;
 	case Kind::GoshVergrth16: id += "goshvergrth16"; break;
+	case Kind::GoshVergrth16WithVK: id += "goshvergrth16withvk"; break;
 	case Kind::GoshPoseidon: id += "goshposeidon"; break;
 	case Kind::GoshZKHALO2VERIFY: id += "goshzkhalo2verify"; break;
 	case Kind::GoshCheckLayerHash: id += "goshchecklayerhash"; break;
@@ -5657,6 +5658,24 @@ MemberList::MemberMap MagicType::nativeMembers(ASTNode const*) const
 				{{}, {}},
 				{{}},
 				FunctionType::Kind::GoshVergrth16,
+				StateMutability::Pure,
+				nullptr, FunctionType::Options::withArbitraryParameters()
+		)});
+
+		// Generic Groth16-on-BN254 verifier: takes (proof, public_inputs, vk)
+		// and returns whether the pairing check holds. Mirrors `vergrth16`
+		// but with the verifying key as an explicit third argument instead
+		// of being hard-coded to the zkLogin VK. Wired to the new TVM
+		// opcode VERGRTH16WITHVK (0xC7 0x49) added in tvm-sdk for the
+		// Ethereum-side Halo2 deposit-event verifier on the AN bridge.
+		members.push_back({
+			"vergrth16WithVK",
+			TypeProvider::function(
+				{TypeProvider::bytesMemory(), TypeProvider::bytesMemory(), TypeProvider::bytesMemory()},
+				{TypeProvider::boolean()},
+				{{}, {}, {}},
+				{{}},
+				FunctionType::Kind::GoshVergrth16WithVK,
 				StateMutability::Pure,
 				nullptr, FunctionType::Options::withArbitraryParameters()
 		)});

--- a/compiler/libsolidity/ast/Types.h
+++ b/compiler/libsolidity/ast/Types.h
@@ -1654,6 +1654,7 @@ public:
 		GoshSHA256,
 		GoshKECCAK256,
 		GoshVergrth16,
+		GoshVergrth16WithVK,
 		GoshPoseidon,
 		GoshZKHALO2VERIFY,
 		GoshCheckLayerHash,

--- a/compiler/libsolidity/codegen/TVMFunctionCall.cpp
+++ b/compiler/libsolidity/codegen/TVMFunctionCall.cpp
@@ -2595,6 +2595,8 @@ void FunctionCallCompiler::goshFunction() {
         		return "KECCAK256";
 			case FunctionType::Kind::GoshVergrth16:
          		return "VERGRTH16";
+			case FunctionType::Kind::GoshVergrth16WithVK:
+         		return "VERGRTH16WITHVK";
 			case FunctionType::Kind::GoshPoseidon:
          		return "POSEIDON";
 			case FunctionType::Kind::GoshZKHALO2VERIFY:

--- a/compiler/libsolidity/codegen/TvmAst.cpp
+++ b/compiler/libsolidity/codegen/TvmAst.cpp
@@ -628,6 +628,7 @@ Pointer<StackOpcode> gen(const std::string& cmd) {
     	{"SHA256", {1, 1, true}},
     	{"KECCAK256", {1, 1, true}},
 		{"VERGRTH16", {2, 1, true}},
+		{"VERGRTH16WITHVK", {3, 1, true}},
 		{"POSEIDON", {7, 1, true}},
 		{"ZKHALO2VERIFY", {2, 1, true}},
 		{"CHKHISTPROOF", {2, 1, true}},


### PR DESCRIPTION
Wires up the new VERGRTH16WITHVK TVM opcode (0xC7 0x49 in tvm-sdk branch serhii/node-3406-vergrth16-with-vk) so that Solidity contracts can call it as `gosh.vergrth16WithVK(proof, public_inputs, vk)`.

The existing `gosh.vergrth16` is hard-bound to the Sui zkLogin verifying key returned by global_pvk() in tvm_vm/src/executor/zk.rs, so it cannot verify Groth16 proofs for any other circuit. The new builtin keeps the same BN254 / arkworks pairing machinery but takes the verifying key as a third bytes argument, making the verifier generic over any Groth16-on-BN254 setup. Primary use case (NODE-3406): the Acki Nacki -> Ethereum bridge needs to verify wrapped Halo2 deposit-event proofs produced on Ethereum inside `TokenBridge. finalizeDeposit`.

Five touch points, all by analogy with the existing `vergrth16`:
  * compiler/libsolidity/ast/Types.h - new FunctionType::Kind enumerator GoshVergrth16WithVK
  * compiler/libsolidity/ast/Types.cpp
      - rich-identifier mapping (goshvergrth16withvk)
      - MagicType::nativeMembers entry for `gosh.vergrth16WithVK` accepting (bytes, bytes, bytes) -> bool, StateMutability::Pure
  * compiler/libsolidity/analysis/ViewPureChecker.cpp - whitelist `vergrth16WithVK` alongside the other pure gosh.*
  * compiler/libsolidity/codegen/TVMFunctionCall.cpp
      - codegen branch returning the "VERGRTH16WITHVK" mnemonic
  * compiler/libsolidity/codegen/TvmAst.cpp - opcode table entry {3, 1, true}: 3 stack inputs, 1 output, pure